### PR TITLE
Revert "fix: event listeners are not registered"

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "prepare": "npm run build",
     "prebuild": "rimraf dist",
     "build": "nest build",
     "sample": "nodemon",

--- a/src/services/listener-explorer.service.ts
+++ b/src/services/listener-explorer.service.ts
@@ -11,7 +11,7 @@ import { MetadataAccessorService } from './metadata-accessor.service';
  * Heavily inspired from [`BullExplorer`](https://github.com/nestjs/bull/blob/c230eab1dc26fb743a3428e61043167866b1e377/lib/bull.explorer.ts)
  */
 @Injectable()
-export class ListenerExplorerService {
+export class ListenerExplorerService implements OnModuleInit {
   private readonly logger = new Logger(ListenerExplorerService.name);
 
   public readonly listeners: { event: WorkerEventName; callback: Function }[] =
@@ -21,7 +21,9 @@ export class ListenerExplorerService {
     private readonly discoveryService: DiscoveryService,
     private readonly metadataAccessor: MetadataAccessorService,
     private readonly metadataScanner: MetadataScanner,
-  ) {
+  ) {}
+
+  onModuleInit() {
     this.explore();
   }
 

--- a/src/services/task-explorer.service.ts
+++ b/src/services/task-explorer.service.ts
@@ -11,7 +11,7 @@ import { MetadataAccessorService } from './metadata-accessor.service';
  * Heavily inspired from [`BullExplorer`](https://github.com/nestjs/bull/blob/c230eab1dc26fb743a3428e61043167866b1e377/lib/bull.explorer.ts)
  */
 @Injectable()
-export class TaskExplorerService {
+export class TaskExplorerService implements OnModuleInit {
   private readonly logger = new Logger(TaskExplorerService.name);
 
   public readonly taskList: TaskList = {};
@@ -20,7 +20,9 @@ export class TaskExplorerService {
     private readonly discoveryService: DiscoveryService,
     private readonly metadataAccessor: MetadataAccessorService,
     private readonly metadataScanner: MetadataScanner,
-  ) {
+  ) {}
+
+  onModuleInit() {
     this.explore();
   }
 

--- a/src/services/worker.service.ts
+++ b/src/services/worker.service.ts
@@ -101,7 +101,7 @@ export class WorkerService {
     for (const event of uniq(events)) {
       this.options.events.on(event, (...args: any[]) => {
         this.listenerExplorerService.listeners
-          .filter((listener) => listener.event === event)
+          .filter(({ event }) => event === event)
           .forEach(({ callback }) => callback(...args));
       });
     }


### PR DESCRIPTION
Reverts madeindjs/nestjs-graphile-worker#4

Because it break test and I'm not sure of behavior using constructor instead of Hooks.