### PR TITLE
fix: await events to be registered

### DIFF
--- a/src/services/listener-explorer.service.ts
+++ b/src/services/listener-explorer.service.ts
@@ -17,6 +17,8 @@ export class ListenerExplorerService implements OnModuleInit {
   public readonly listeners: { event: WorkerEventName; callback: Function }[] =
     [];
 
+  private resolveInitialized: () => void;
+
   constructor(
     private readonly discoveryService: DiscoveryService,
     private readonly metadataAccessor: MetadataAccessorService,
@@ -25,6 +27,12 @@ export class ListenerExplorerService implements OnModuleInit {
 
   onModuleInit() {
     this.explore();
+  }
+
+  async ensureInitialized(): Promise<void> {
+    return new Promise((resolve) => {
+      this.resolveInitialized = resolve;
+    });
   }
 
   explore() {
@@ -59,6 +67,8 @@ export class ListenerExplorerService implements OnModuleInit {
           }
         },
       );
+
+      this.resolveInitialized();
     });
   }
 }

--- a/src/services/worker.service.ts
+++ b/src/services/worker.service.ts
@@ -93,7 +93,8 @@ export class WorkerService {
     this.isMigrationDone = true;
   }
 
-  private hookEvents() {
+  private async hookEvents() {
+    await this.listenerExplorerService.ensureInitialized();
     const events = this.listenerExplorerService.listeners.map(
       ({ event }) => event,
     );


### PR DESCRIPTION
This PR attempts to fix issue #3 

After some debugging, I found out that this code block
```js
const events = this.listenerExplorerService.listeners.map(
      ({ event }) => event,
);
```
is being called with empty events, meaning the `listenerExplorerService` hasn't been fully initialized yet. This fix awaits the `listenerExplorerService` to be fully initialized before registering the events.