### PR TITLE
fix: call correct listeners when worker event received

### DIFF
--- a/src/services/worker.service.ts
+++ b/src/services/worker.service.ts
@@ -102,7 +102,7 @@ export class WorkerService {
     for (const event of uniq(events)) {
       this.options.events.on(event, (...args: any[]) => {
         this.listenerExplorerService.listeners
-          .filter(({ event }) => event === event)
+          .filter(({ event: e }) => e === event)
           .forEach(({ callback }) => callback(...args));
       });
     }


### PR DESCRIPTION
The current implementation has a bug that compares a variable to itself resulting in all listener callbacks being fired.

Thanks!