### PR TITLE
Fix peer dependencies error when using Nest 9

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
     "typescript": "^4.9.4"
   },
   "peerDependencies": {
-    "@nestjs/common": "^10.0.0",
-    "@nestjs/core": "^10.0.0",
+    "@nestjs/common": "^9.0.0 || ^10.0.0",
+    "@nestjs/core": "^9.0.0 || ^10.0.0",
     "graphile-worker": "^0.13.0"
   },
   "jest": {


### PR DESCRIPTION
As of https://github.com/madeindjs/nestjs-graphile-worker/pull/13 the nestjs-graphile-worker library supports both Nest 9 and Nest 10. However, the peerDependencies specified only Nest 10, thus causing peer dependency install errors when using it in a Nest 9 codebase.

This change relaxes the strong Nest 10 peer dependency and allows installing it with Nest 9 again, following the examples of the packages in the @nestjs scope such as https://github.com/nestjs/serve-static/blob/6fa7f98a94131bbd08724fd33683979bcd256064/package.json#L21C24-L21C41 