### PR TITLE
feat: allow custom logger

### DIFF
--- a/src/graphile-worker.module.ts
+++ b/src/graphile-worker.module.ts
@@ -112,8 +112,8 @@ function buildRunnerOptions(
   const events = new EventEmitter();
 
   return {
-    ...configuration,
     logger: RunnerLogger,
+    ...configuration,
     events,
   };
 }


### PR DESCRIPTION
Before, any Logger passed in with `configuration` gets overwritten by RunnerLogger:
```
  return {
    ...configuration,
    logger: RunnerLogger,
    events,
  };
  ```
  After, RunnerLogger is used by default but overwritten by any configuration passed in
  ```
return {
    logger: RunnerLogger,
    ...configuration,
    events,
};
  ```