### PR TITLE
fix: prevent undefined appearing after debug logs in Graphile Worker

### DIFF
--- a/src/utils/graphile-worker-logger.utils.spec.ts
+++ b/src/utils/graphile-worker-logger.utils.spec.ts
@@ -1,0 +1,74 @@
+import { LogLevel } from "@graphile/logger";
+import * as assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { NestLikeLogger } from "./graphile-worker-logger.utils";
+import { createGraphileWorkerLogFunction } from "./graphile-worker-logger.utils";
+
+function createMockLogger() {
+  const calls: { method: string; args: unknown[] }[] = [];
+  const logger: NestLikeLogger = {
+    debug: (message) => calls.push({ method: "debug", args: [message] }),
+    error: (message) => calls.push({ method: "error", args: [message] }),
+    warn: (message) => calls.push({ method: "warn", args: [message] }),
+    log: (message) => calls.push({ method: "log", args: [message] }),
+  };
+  return { logger, calls };
+}
+
+const LEVEL_TO_METHOD: Record<string, string> = {
+  [LogLevel.DEBUG]: "debug",
+  [LogLevel.ERROR]: "error",
+  [LogLevel.WARNING]: "warn",
+  [LogLevel.INFO]: "log",
+};
+
+describe("createGraphileWorkerLogFunction", () => {
+  describe("without meta (single argument only)", () => {
+    const cases = [
+      { level: LogLevel.DEBUG, message: "Spawned" },
+      { level: LogLevel.ERROR, message: "error msg" },
+      { level: LogLevel.WARNING, message: "warning msg" },
+      { level: LogLevel.INFO, message: "info msg" },
+    ];
+
+    for (const { level, message } of cases) {
+      const expectedMethod = LEVEL_TO_METHOD[level];
+      it(`${expectedMethod}: invokes logger.${expectedMethod} once with message only`, () => {
+        const { logger, calls } = createMockLogger();
+        const logFn = createGraphileWorkerLogFunction(logger);
+
+        logFn(level, message, undefined);
+
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(calls[0].method, expectedMethod);
+        assert.deepEqual(calls[0].args, [message]);
+      });
+    }
+  });
+
+  describe("with meta (appended to message string, not as second argument)", () => {
+    const cases = [
+      { level: LogLevel.DEBUG, message: "msg", meta: { foo: "bar" } },
+      { level: LogLevel.ERROR, message: "failed", meta: { code: "E001" } },
+      { level: LogLevel.WARNING, message: "deprecated", meta: { since: "v2" } },
+      { level: LogLevel.INFO, message: "started", meta: { taskId: 1 } },
+    ];
+
+    for (const { level, message, meta } of cases) {
+      const expectedMethod = LEVEL_TO_METHOD[level];
+      it(`${expectedMethod}: includes meta in message string`, () => {
+        const { logger, calls } = createMockLogger();
+        const logFn = createGraphileWorkerLogFunction(logger);
+
+        logFn(level, message, meta);
+
+        assert.strictEqual(calls.length, 1);
+        assert.strictEqual(calls[0].method, expectedMethod);
+        assert.strictEqual(calls[0].args.length, 1);
+        const logged = String(calls[0].args[0]);
+        assert.ok(logged.includes(message));
+        assert.ok(logged.includes(JSON.stringify(meta)));
+      });
+    }
+  });
+});

--- a/src/utils/graphile-worker-logger.utils.ts
+++ b/src/utils/graphile-worker-logger.utils.ts
@@ -2,9 +2,16 @@ import type { LogFunction, LogLevel, LogMeta } from "@graphile/logger";
 import { Logger as GraphileLogger } from "@graphile/logger";
 import { Logger } from "@nestjs/common";
 
-function graphileWorkerLogFactory(): LogFunction {
-  const logger = new Logger("GraphileWorker");
+export interface NestLikeLogger {
+  debug: (message: string) => void;
+  error: (message: string) => void;
+  log: (message: string) => void;
+  warn: (message: string) => void;
+}
 
+export function createGraphileWorkerLogFunction(
+  logger: NestLikeLogger,
+): LogFunction {
   return (level: LogLevel, message: string, meta?: LogMeta) => {
     if (meta !== undefined) {
       message += ` - ${JSON.stringify(meta)}`;
@@ -21,10 +28,15 @@ function graphileWorkerLogFactory(): LogFunction {
         logger.log(message);
         break;
       case "debug":
-        logger.debug(message, meta);
+        logger.debug(message);
         break;
     }
   };
+}
+
+function graphileWorkerLogFactory(_scope?: object): LogFunction {
+  const logger = new Logger("GraphileWorker");
+  return createGraphileWorkerLogFunction(logger);
 }
 
 export const RunnerLogger = new GraphileLogger(graphileWorkerLogFactory);


### PR DESCRIPTION
# Fix Graphile Worker debug logger printing "undefined"

## Problem
Every Graphile Worker debug log was followed by a spurious line printing `undefined`.

## Cause
The `debug` branch was the only one passing `meta` to Nest's `Logger.debug()`. When `meta` is `undefined` (most debug calls), Nest still receives it and prints it as a second line.

## Solution
- Stop passing `meta` in the `debug` branch: use `logger.debug(message)` only (same as other levels).
- Add `NestLikeLogger` interface and extract `createGraphileWorkerLogFunction` for testability.
- Add unit tests for the logger util.