### PR TITLE
ci: update GitHub Actions to v4 to fix Node.js 20 deprecation

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,9 +6,9 @@ jobs:
   unit-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Use Node.js 24.x
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: 24.x
 


### PR DESCRIPTION
- actions/checkout@v2 → actions/checkout@v4
- actions/setup-node@v1 → actions/setup-node@v4